### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ iOS Open Source Application written in Swift. App to manage borrowed books at UF
 
 App in portuguese, code and comments in english. Available for iOS 8.0.
 
-**IMPORTANT**: This project uses Cocoapods as the dependency manager, make sure you have it installed. After download or clone it, apply the following command in the directory of the project:
+**IMPORTANT**: This project uses CocoaPods as the dependency manager, make sure you have it installed. After download or clone it, apply the following command in the directory of the project:
 
 ```
 pod install 


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
